### PR TITLE
Fix bug for regex to match UUID4

### DIFF
--- a/src/Validation/Validators/UuidV4.php
+++ b/src/Validation/Validators/UuidV4.php
@@ -12,6 +12,6 @@ class UuidV4 implements ValidatorInterface
             return false;
         }
 
-        return preg_match('/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/', $value);
+        return preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $value);
     }
 }


### PR DESCRIPTION
Add '^' and '$' to guarantee all input string match uuid4 format.